### PR TITLE
Code refactor and optimization

### DIFF
--- a/examples/connect_example/wifi_connect.go
+++ b/examples/connect_example/wifi_connect.go
@@ -3,24 +3,26 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 
 	wifi "github.com/mark2b/wpa-connect"
-	"time"
 )
 
 func main() {
-
 	args := os.Args[1:]
 	if len(args) < 2 {
 		fmt.Println("Insufficient arguments")
 		return
 	}
+
 	ssid := args[0]
 	password := args[1]
 	wifi.SetDebugMode()
-	if conn, err := wifi.ConnectManager.Connect(ssid, password, time.Second * 60); err == nil {
-		fmt.Println("Connected", conn.NetInterface, conn.SSID, conn.IP4.String(), conn.IP6.String())
-	} else {
-		fmt.Println(err)
+
+	conn, err := wifi.ConnectManager.Connect(ssid, password, time.Second*60)
+	if err != nil {
+		panic(err)
 	}
+
+	fmt.Println("Connected", conn.NetInterface, conn.SSID, conn.IP4.String(), conn.IP6.String())
 }

--- a/examples/scan_example/wifi_scan.go
+++ b/examples/scan_example/wifi_scan.go
@@ -1,13 +1,18 @@
 package main
 
 import (
+	"fmt"
+
 	wifi "github.com/mark2b/wpa-connect"
 )
 
 func main() {
-	if bssList, err := wifi.ScanManager.Scan(); err == nil {
-		for _, bss := range bssList {
-			print(bss.SSID, bss.Signal, bss.KeyMgmt)
-		}
+	bssList, err := wifi.ScanManager.Scan()
+	if err != nil {
+		panic(err)
+	}
+
+	for _, bss := range bssList {
+		fmt.Println(bss.SSID, bss.Signal, bss.KeyMgmt)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,6 @@ module github.com/mark2b/wpa-connect
 go 1.15
 
 require (
-	github.com/ThomasRooney/gexpect v0.0.0-20161231170123-5482f0350944
 	github.com/godbus/dbus v4.1.0+incompatible
-	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
-	github.com/kr/pty v1.1.8 // indirect
 	github.com/op/go-logging v0.0.0-20160315200505-970db520ece7
-	golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,16 +1,4 @@
-github.com/ThomasRooney/gexpect v0.0.0-20161231170123-5482f0350944 h1:CjexZrggt4RldpEUXFZf52vSO3cnmFaqW6B4wADj05Q=
-github.com/ThomasRooney/gexpect v0.0.0-20161231170123-5482f0350944/go.mod h1:sPML5WwI6oxLRLPuuqbtoOKhtmpVDCYtwsps+I+vjIY=
-github.com/creack/pty v1.1.7 h1:6pwm8kMQKCmgUg0ZHTm5+/YvRK0s3THD/28+T6/kk4A=
-github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/godbus/dbus v4.1.0+incompatible h1:WqqLRTsQic3apZUK9qC5sGNfXthmPXzUZ7nQPrNITa4=
 github.com/godbus/dbus v4.1.0+incompatible/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
-github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
-github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
-github.com/kr/pty v1.1.8 h1:AkaSdXYQOWeaO3neb8EM634ahkXXe3jYbVh/F9lq+GI=
-github.com/kr/pty v1.1.8/go.mod h1:O1sed60cT9XZ5uDucP5qwvh+TE3NnUj51EiZO/lmSfw=
-wpa-connect v0.0.0-20180831215415-bfacdc9df2b3 h1:YVu7NVMVx9uYw+F7QZhc1pABp5nge+tOMR2WJOqLUYQ=
-wpa-connect v0.0.0-20180831215415-bfacdc9df2b3/go.mod h1:xoRsEIkcdIp+aq7WjBKc0FGoEtmUEYDaec8xDVTAyCk=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7 h1:lDH9UUVJtmYCjyT0CI4q8xvlXPxeZ0gYCVvWbmPlp88=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
-golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634 h1:bNEHhJCnrwMKNMmOx3yAynp5vs5/gRy+XWFtZFu7NBM=
-golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/wpa_cli/wpa_cli.go
+++ b/internal/wpa_cli/wpa_cli.go
@@ -12,9 +12,5 @@ type WPACli struct {
 func (self *WPACli) SaveConfig() (e error) {
 	cmd := exec.Command("wpa_cli", fmt.Sprintf("-i%s", self.NetInterface), "save_config")
 
-	if err := cmd.Start(); err == nil {
-	} else {
-		e = err
-	}
-	return
+	return cmd.Start()
 }

--- a/internal/wpa_dbus/wpa.go
+++ b/internal/wpa_dbus/wpa.go
@@ -17,60 +17,76 @@ type WPA struct {
 	Error         error
 }
 
-func NewWPA() (wpa *WPA, e error) {
-	if conn, err := dbus.SystemBus(); err == nil {
-		if obj := conn.Object("fi.w1.wpa_supplicant1", "/fi/w1/wpa_supplicant1"); obj != nil {
-			wpa = &WPA{Connection: conn, Object: obj}
-		} else {
-			conn.Close()
-			err = errors.New("Can't create WPA object")
-		}
-	} else {
-		e = err
+func NewWPA() (*WPA, error) {
+	conn, err := dbus.SystemBus()
+	if err != nil {
+		return nil, err
 	}
 
-	return
+	if obj := conn.Object("fi.w1.wpa_supplicant1", "/fi/w1/wpa_supplicant1"); obj != nil {
+		return &WPA{Connection: conn, Object: obj}, nil
+	}
+
+	conn.Close()
+	return nil, errors.New("Can't create WPA object")
 }
 
 func (self *WPA) ReadInterface(ifname string) *WPA {
-	if self.Error == nil {
-		if call := self.Object.Call("fi.w1.wpa_supplicant1.GetInterface", 0, ifname); call.Err == nil {
-			var objectPath = dbus.ObjectPath(call.Body[0].(dbus.ObjectPath))
-			self.Interface = &InterfaceWPA{WPA: self, Object: self.Connection.Object("fi.w1.wpa_supplicant1", objectPath)}
-		} else {
-			self.Error = call.Err
-		}
+	if self.Error != nil {
+		return self
 	}
+
+	call := self.Object.Call("fi.w1.wpa_supplicant1.GetInterface", 0, ifname)
+	if call.Err != nil {
+		self.Error = call.Err
+		return self
+	}
+
+	objectPath := dbus.ObjectPath(call.Body[0].(dbus.ObjectPath))
+	self.Interface = &InterfaceWPA{
+		WPA:    self,
+		Object: self.Connection.Object("fi.w1.wpa_supplicant1", objectPath),
+	}
+
 	return self
 }
 
 func (self *WPA) ReadInterfaceList() *WPA {
-	if self.Error == nil {
-		if interfaces, err := self.get("fi.w1.wpa_supplicant1.Interfaces", self.Object); err == nil {
-			newInterfaces := []InterfaceWPA{}
-			for _, interfaceObjectPath := range interfaces.([]dbus.ObjectPath) {
-				iface := InterfaceWPA{WPA: self, Object: self.Connection.Object("fi.w1.wpa_supplicant1", interfaceObjectPath)}
-				newInterfaces = append(newInterfaces, iface)
-			}
-			self.Interfaces = newInterfaces
-		} else {
-			self.Error = err
-		}
+	if self.Error != nil {
+		return self
 	}
+
+	interfaces, err := self.get("fi.w1.wpa_supplicant1.Interfaces", self.Object)
+	if err != nil {
+		self.Error = err
+		return self
+	}
+
+	newInterfaces := []InterfaceWPA{}
+	for _, interfaceObjectPath := range interfaces.([]dbus.ObjectPath) {
+		iface := InterfaceWPA{
+			WPA:    self,
+			Object: self.Connection.Object("fi.w1.wpa_supplicant1", interfaceObjectPath),
+		}
+		newInterfaces = append(newInterfaces, iface)
+	}
+	self.Interfaces = newInterfaces
+
 	return self
 }
 
-func (self *WPA) get(name string, target dbus.BusObject) (value interface{}, e error) {
-	if variant, err := target.GetProperty(name); err == nil {
-		value = variant.Value()
-	} else {
-		e = err
+func (self *WPA) get(name string, target dbus.BusObject) (interface{}, error) {
+	variant, err := target.GetProperty(name)
+	if err != nil {
+		return nil, err
 	}
-	return
+
+	return variant.Value(), nil
 }
 
 func (self *WPA) WaitForSignals(callBack func(*WPA, *dbus.Signal)) *WPA {
 	log.Log.Debug("WaitForSignals")
+
 	self.SignalChannel = make(chan *dbus.Signal, 10)
 	self.Connection.Signal(self.SignalChannel)
 	go func() {
@@ -78,31 +94,34 @@ func (self *WPA) WaitForSignals(callBack func(*WPA, *dbus.Signal)) *WPA {
 			callBack(self, ch)
 		}
 	}()
+
 	return self
 }
 
 func (self *WPA) StopWaitForSignals() *WPA {
 	log.Log.Debug("StopWaitForSignals")
+
 	self.Connection.RemoveSignal(self.SignalChannel)
+
 	return self
 }
 
 func (self *WPA) AddSignalsObserver() *WPA {
 	log.Log.Debug("AddSignalsObserver.WPA")
+
 	match := fmt.Sprintf("type='signal',interface='fi.w1.wpa_supplicant1',path='%s'", self.Object.Path())
-	if call := self.Connection.BusObject().Call("org.freedesktop.DBus.AddMatch", 0, match); call.Err == nil {
-	} else {
-		self.Error = call.Err
-	}
+	call := self.Connection.BusObject().Call("org.freedesktop.DBus.AddMatch", 0, match)
+	self.Error = call.Err
+
 	return self
 }
 
 func (self *WPA) RemoveSignalsObserver() *WPA {
 	log.Log.Debug("RemoveSignalsObserver.WPA")
+
 	match := fmt.Sprintf("type='signal',interface='fi.w1.wpa_supplicant1',path='%s'", self.Object.Path())
-	if call := self.Connection.BusObject().Call("org.freedesktop.DBus.RemoveMatch", 0, match); call.Err == nil {
-	} else {
-		self.Error = call.Err
-	}
+	call := self.Connection.BusObject().Call("org.freedesktop.DBus.RemoveMatch", 0, match)
+	self.Error = call.Err
+
 	return self
 }

--- a/internal/wpa_dbus/wpa_bss.go
+++ b/internal/wpa_dbus/wpa_bss.go
@@ -26,149 +26,186 @@ type BSSWPA struct {
 }
 
 func (self *BSSWPA) ReadWPA() *BSSWPA {
-	if self.Error == nil {
-		if value, err := self.Interface.WPA.get("fi.w1.wpa_supplicant1.BSS.WPA", self.Object); err == nil {
-			if value, ok := value.(map[string]dbus.Variant); ok {
-				for key, variant := range value {
-					if key == "KeyMgmt" {
-						self.WPAKeyMgmt = variant.Value().([]string)
-					}
-				}
-			}
-		} else {
-			self.Error = err
+	if self.Error != nil {
+		return self
+	}
+
+	variants, err := self.Interface.WPA.get("fi.w1.wpa_supplicant1.BSS.WPA", self.Object)
+	if err != nil {
+		self.Error = err
+		return self
+	}
+
+	if variants, ok := variants.(map[string]dbus.Variant); ok {
+		if keyMgmt, found := variants["KeyMgmt"]; found {
+			self.RSNKeyMgmt = keyMgmt.Value().([]string)
 		}
 	}
+
 	return self
 }
 
 func (self *BSSWPA) ReadRSN() *BSSWPA {
-	if self.Error == nil {
-		if value, err := self.Interface.WPA.get("fi.w1.wpa_supplicant1.BSS.RSN", self.Object); err == nil {
-			if value, ok := value.(map[string]dbus.Variant); ok {
-				for key, variant := range value {
-					if key == "KeyMgmt" {
-						self.RSNKeyMgmt = variant.Value().([]string)
-					}
-				}
-			}
-		} else {
-			self.Error = err
+	if self.Error != nil {
+		return self
+	}
+
+	variants, err := self.Interface.WPA.get("fi.w1.wpa_supplicant1.BSS.RSN", self.Object)
+	if err != nil {
+		self.Error = err
+		return self
+	}
+
+	if variants, ok := variants.(map[string]dbus.Variant); ok {
+		if keyMgmt, found := variants["KeyMgmt"]; found {
+			self.RSNKeyMgmt = keyMgmt.Value().([]string)
 		}
 	}
+
 	return self
 }
 
 func (self *BSSWPA) ReadWPS() *BSSWPA {
-	if self.Error == nil {
-		if value, err := self.Interface.WPA.get("fi.w1.wpa_supplicant1.BSS.WPS", self.Object); err == nil {
-			if value, ok := value.(map[string]dbus.Variant); ok {
-				for key, variant := range value {
-					if key == "Type" {
-						self.WPS = variant.Value().(string)
-					}
-				}
-			}
-		} else {
-			self.Error = err
+	if self.Error != nil {
+		return self
+	}
+
+	variants, err := self.Interface.WPA.get("fi.w1.wpa_supplicant1.BSS.WPS", self.Object)
+	if err != nil {
+		self.Error = err
+		return self
+	}
+
+	if variants, ok := variants.(map[string]dbus.Variant); ok {
+		if wpsType, found := variants["Type"]; found {
+			self.WPS = wpsType.String()
 		}
 	}
+
 	return self
 }
 
 func (self *BSSWPA) ReadBSSID() *BSSWPA {
-	if self.Error == nil {
-		if value, err := self.Interface.WPA.get("fi.w1.wpa_supplicant1.BSS.BSSID", self.Object); err == nil {
-			self.BSSID = hex.EncodeToString(value.([]byte))
-		} else {
-			self.Error = err
-		}
+	if self.Error != nil {
+		return self
 	}
+
+	value, err := self.Interface.WPA.get("fi.w1.wpa_supplicant1.BSS.BSSID", self.Object)
+	if err != nil {
+		self.Error = err
+		return self
+	}
+	self.BSSID = hex.EncodeToString(value.([]byte))
+
 	return self
 }
 
 func (self *BSSWPA) ReadSSID() *BSSWPA {
-	if self.Error == nil {
-		if value, err := self.Interface.WPA.get("fi.w1.wpa_supplicant1.BSS.SSID", self.Object); err == nil {
-			self.SSID = string(value.([]byte))
-		} else {
-			self.Error = err
-		}
+	if self.Error != nil {
+		return self
 	}
+
+	value, err := self.Interface.WPA.get("fi.w1.wpa_supplicant1.BSS.SSID", self.Object)
+	if err != nil {
+		self.Error = err
+		return self
+	}
+	self.SSID = string(value.([]byte))
+
 	return self
 }
 
 func (self *BSSWPA) ReadFrequency() *BSSWPA {
-	if self.Error == nil {
-		if value, err := self.Interface.WPA.get("fi.w1.wpa_supplicant1.BSS.Frequency", self.Object); err == nil {
-			self.Frequency = value.(uint16)
-		} else {
-			self.Error = err
-		}
+	if self.Error != nil {
+		return self
 	}
+
+	value, err := self.Interface.WPA.get("fi.w1.wpa_supplicant1.BSS.Frequency", self.Object)
+	if err != nil {
+		self.Error = err
+		return self
+	}
+	self.Frequency = value.(uint16)
+
 	return self
 }
 
 func (self *BSSWPA) ReadSignal() *BSSWPA {
-	if self.Error == nil {
-		if value, err := self.Interface.WPA.get("fi.w1.wpa_supplicant1.BSS.Signal", self.Object); err == nil {
-			self.Signal = value.(int16)
-		} else {
-			self.Error = err
-		}
+	if self.Error != nil {
+		return self
 	}
+
+	value, err := self.Interface.WPA.get("fi.w1.wpa_supplicant1.BSS.Signal", self.Object)
+	if err != nil {
+		self.Error = err
+		return self
+	}
+	self.Signal = value.(int16)
+
 	return self
 }
 
 func (self *BSSWPA) ReadAge() *BSSWPA {
-	if self.Error == nil {
-		if value, err := self.Interface.WPA.get("fi.w1.wpa_supplicant1.BSS.Age", self.Object); err == nil {
-			self.Age = value.(uint32)
-		} else {
-			self.Error = err
-		}
+	if self.Error != nil {
+		return self
 	}
+
+	value, err := self.Interface.WPA.get("fi.w1.wpa_supplicant1.BSS.Age", self.Object)
+	if err != nil {
+		self.Error = err
+		return self
+	}
+	self.Age = value.(uint32)
+
 	return self
 }
 
 func (self *BSSWPA) ReadMode() *BSSWPA {
-	if self.Error == nil {
-		if value, err := self.Interface.WPA.get("fi.w1.wpa_supplicant1.BSS.Mode", self.Object); err == nil {
-			self.Mode = value.(string)
-		} else {
-			self.Error = err
-		}
+	if self.Error != nil {
+		return self
 	}
+
+	value, err := self.Interface.WPA.get("fi.w1.wpa_supplicant1.BSS.Mode", self.Object)
+	if err != nil {
+		self.Error = err
+		return self
+	}
+	self.Mode = value.(string)
+
 	return self
 }
 
 func (self *BSSWPA) ReadPrivacy() *BSSWPA {
-	if self.Error == nil {
-		if value, err := self.Interface.WPA.get("fi.w1.wpa_supplicant1.BSS.Privacy", self.Object); err == nil {
-			self.Privacy = value.(bool)
-		} else {
-			self.Error = err
-		}
+	if self.Error != nil {
+		return self
 	}
+
+	value, err := self.Interface.WPA.get("fi.w1.wpa_supplicant1.BSS.Privacy", self.Object)
+	if err != nil {
+		self.Error = err
+		return self
+	}
+	self.Privacy = value.(bool)
+
 	return self
 }
 
 func (self *BSSWPA) AddSignalsObserver() *BSSWPA {
 	log.Log.Debug("AddSignalsObserver.BSS")
 	match := fmt.Sprintf("type='signal',interface='fi.w1.wpa_supplicant1.BSS',path='%s'", self.Object.Path())
-	if call := self.Interface.WPA.Connection.BusObject().Call("org.freedesktop.DBus.AddMatch", 0, match); call.Err == nil {
-	} else {
-		self.Error = call.Err
-	}
+
+	call := self.Interface.WPA.Connection.BusObject().Call("org.freedesktop.DBus.AddMatch", 0, match)
+	self.Error = call.Err
+
 	return self
 }
 
 func (self *BSSWPA) RemoveSignalsObserver() *BSSWPA {
 	log.Log.Debug("RemoveSignalsObserver.BSS")
 	match := fmt.Sprintf("type='signal',interface='fi.w1.wpa_supplicant1.BSS',path='%s'", self.Object.Path())
-	if call := self.Interface.WPA.Connection.BusObject().Call("org.freedesktop.DBus.RemoveMatch", 0, match); call.Err == nil {
-	} else {
-		self.Error = call.Err
-	}
+
+	call := self.Interface.WPA.Connection.BusObject().Call("org.freedesktop.DBus.RemoveMatch", 0, match)
+	self.Error = call.Err
+
 	return self
 }

--- a/internal/wpa_dbus/wpa_interface.go
+++ b/internal/wpa_dbus/wpa_interface.go
@@ -26,213 +26,268 @@ type InterfaceWPA struct {
 }
 
 func (self *InterfaceWPA) ReadNetworksList() *InterfaceWPA {
-	if self.Error == nil {
-		if networks, err := self.WPA.get("fi.w1.wpa_supplicant1.Interface.Networks", self.Object); err == nil {
-			newNetworks := []NetworkWPA{}
-			for _, networkObjectPath := range networks.([]dbus.ObjectPath) {
-				network := NetworkWPA{Interface: self, Object: self.WPA.Connection.Object("fi.w1.wpa_supplicant1", networkObjectPath)}
-				newNetworks = append(newNetworks, network)
-			}
-			self.Networks = newNetworks
-		} else {
-			self.Error = err
-		}
+	if self.Error != nil {
+		return self
 	}
+
+	networks, err := self.WPA.get("fi.w1.wpa_supplicant1.Interface.Networks", self.Object)
+	if err != nil {
+		self.Error = err
+		return self
+	}
+
+	newNetworks := []NetworkWPA{}
+	for _, networkObjectPath := range networks.([]dbus.ObjectPath) {
+		network := NetworkWPA{Interface: self, Object: self.WPA.Connection.Object("fi.w1.wpa_supplicant1", networkObjectPath)}
+		newNetworks = append(newNetworks, network)
+	}
+	self.Networks = newNetworks
+
 	return self
 }
 
 func (self *InterfaceWPA) MakeTempBSS() *InterfaceWPA {
-	self.TempBSS = &BSSWPA{Interface: self, Object: self.WPA.Connection.Object("fi.w1.wpa_supplicant1", "/")}
+	self.TempBSS = &BSSWPA{
+		Interface: self,
+		Object:    self.WPA.Connection.Object("fi.w1.wpa_supplicant1", "/"),
+	}
 	return self
 }
 
 func (self *InterfaceWPA) ReadBSSList() *InterfaceWPA {
-	if self.Error == nil {
-		if bsss, err := self.WPA.get("fi.w1.wpa_supplicant1.Interface.BSSs", self.Object); err == nil {
-			newBSSs := []BSSWPA{}
-			for _, bssObjectPath := range bsss.([]dbus.ObjectPath) {
-				bss := BSSWPA{Interface: self, Object: self.WPA.Connection.Object("fi.w1.wpa_supplicant1", bssObjectPath)}
-				newBSSs = append(newBSSs, bss)
-			}
-			self.BSSs = newBSSs
-		} else {
-			self.Error = err
-		}
+	if self.Error != nil {
+		return self
 	}
+
+	bsss, err := self.WPA.get("fi.w1.wpa_supplicant1.Interface.BSSs", self.Object)
+	if err != nil {
+		self.Error = err
+		return self
+	}
+
+	newBSSs := []BSSWPA{}
+	for _, bssObjectPath := range bsss.([]dbus.ObjectPath) {
+		bss := BSSWPA{Interface: self, Object: self.WPA.Connection.Object("fi.w1.wpa_supplicant1", bssObjectPath)}
+		newBSSs = append(newBSSs, bss)
+	}
+	self.BSSs = newBSSs
+
 	return self
 }
 
 func (self *InterfaceWPA) Scan() *InterfaceWPA {
-	if self.Error == nil {
-		args := make(map[string]dbus.Variant, 0)
-		args["Type"] = dbus.MakeVariant("passive")
-		if call := self.Object.Call("fi.w1.wpa_supplicant1.Interface.Scan", 0, args); call.Err == nil {
-		} else {
-			self.Error = call.Err
-		}
+	if self.Error != nil {
+		return self
 	}
+
+	args := make(map[string]dbus.Variant, 0)
+	args["Type"] = dbus.MakeVariant("passive")
+	call := self.Object.Call("fi.w1.wpa_supplicant1.Interface.Scan", 0, args)
+	self.Error = call.Err
+
 	return self
 }
 
 func (self *InterfaceWPA) Disconnect() *InterfaceWPA {
-	if self.Error == nil {
-		if call := self.Object.Call("fi.w1.wpa_supplicant1.Interface.Disconnect", 0); call.Err == nil {
-		} else {
-			self.Error = call.Err
-		}
+	if self.Error != nil {
+		return self
 	}
+
+	call := self.Object.Call("fi.w1.wpa_supplicant1.Interface.Disconnect", 0)
+	self.Error = call.Err
+
 	return self
 }
 
 func (self *InterfaceWPA) Reassociate() *InterfaceWPA {
-	if self.Error == nil {
-		if call := self.Object.Call("fi.w1.wpa_supplicant1.Interface.Reassociate", 0); call.Err == nil {
-		} else {
-			self.Error = call.Err
-		}
+	if self.Error != nil {
+		return self
 	}
+
+	call := self.Object.Call("fi.w1.wpa_supplicant1.Interface.Reassociate", 0)
+	self.Error = call.Err
+
 	return self
 }
 
 func (self *InterfaceWPA) Reattach() *InterfaceWPA {
-	if self.Error == nil {
-		if call := self.Object.Call("fi.w1.wpa_supplicant1.Interface.Reattach", 0); call.Err == nil {
-		} else {
-			self.Error = call.Err
-		}
+	if self.Error != nil {
+		return self
 	}
+
+	call := self.Object.Call("fi.w1.wpa_supplicant1.Interface.Reattach", 0)
+	self.Error = call.Err
+
 	return self
 }
 
 func (self *InterfaceWPA) Reconnect() *InterfaceWPA {
-	if self.Error == nil {
-		if call := self.Object.Call("fi.w1.wpa_supplicant1.Interface.Reconnect", 0); call.Err == nil {
-		} else {
-			self.Error = call.Err
-		}
+	if self.Error != nil {
+		return self
 	}
+
+	call := self.Object.Call("fi.w1.wpa_supplicant1.Interface.Reconnect", 0)
+	self.Error = call.Err
+
 	return self
 }
 
 func (self *InterfaceWPA) RemoveAllNetworks() *InterfaceWPA {
-	if self.Error == nil {
-		if call := self.Object.Call("fi.w1.wpa_supplicant1.Interface.RemoveAllNetworks", 0); call.Err == nil {
-		} else {
-			self.Error = call.Err
-		}
+	if self.Error != nil {
+		return self
 	}
+
+	call := self.Object.Call("fi.w1.wpa_supplicant1.Interface.RemoveAllNetworks", 0)
+	self.Error = call.Err
+
 	return self
 }
 
 func (self *InterfaceWPA) AddNetwork(args map[string]dbus.Variant) *InterfaceWPA {
-	if self.Error == nil {
-		if call := self.Object.Call("fi.w1.wpa_supplicant1.Interface.AddNetwork", 0, args); call.Err == nil {
-			if len(call.Body) > 0 {
-				networkObjectPath := call.Body[0].(dbus.ObjectPath)
-				self.NewNetwork = &NetworkWPA{Interface: self, Object: self.WPA.Connection.Object("fi.w1.wpa_supplicant1", networkObjectPath)}
-			}
-		} else {
-			self.Error = call.Err
-		}
+	if self.Error != nil {
+		return self
 	}
+
+	call := self.Object.Call("fi.w1.wpa_supplicant1.Interface.AddNetwork", 0, args)
+	if call.Err != nil {
+		self.Error = call.Err
+		return self
+	}
+
+	if len(call.Body) > 0 {
+		networkObjectPath := call.Body[0].(dbus.ObjectPath)
+		self.NewNetwork = &NetworkWPA{Interface: self, Object: self.WPA.Connection.Object("fi.w1.wpa_supplicant1", networkObjectPath)}
+	}
+
 	return self
 }
 
 func (self *InterfaceWPA) ReadState() *InterfaceWPA {
-	if self.Error == nil {
-		if value, err := self.WPA.get("fi.w1.wpa_supplicant1.Interface.State", self.Object); err == nil {
-			self.State = value.(string)
-		} else {
-			self.Error = err
-		}
+	if self.Error != nil {
+		return self
 	}
+
+	value, err := self.WPA.get("fi.w1.wpa_supplicant1.Interface.State", self.Object)
+	if err != nil {
+		self.Error = err
+		return self
+	}
+	self.State = value.(string)
+
 	return self
 }
 
 func (self *InterfaceWPA) ReadScanning() *InterfaceWPA {
-	if self.Error == nil {
-		if value, err := self.WPA.get("fi.w1.wpa_supplicant1.Interface.Scanning", self.Object); err == nil {
-			self.Scanning = value.(bool)
-		} else {
-			self.Error = err
-		}
+	if self.Error != nil {
+		return self
 	}
+
+	value, err := self.WPA.get("fi.w1.wpa_supplicant1.Interface.Scanning", self.Object)
+	if err != nil {
+		self.Error = err
+		return self
+	}
+	self.Scanning = value.(bool)
+
 	return self
 }
 
 func (self *InterfaceWPA) ReadIfname() *InterfaceWPA {
-	if self.Error == nil {
-		if value, err := self.WPA.get("fi.w1.wpa_supplicant1.Interface.Ifname", self.Object); err == nil {
-			self.Ifname = value.(string)
-		} else {
-			self.Error = err
-		}
+	if self.Error != nil {
+		return self
 	}
+
+	value, err := self.WPA.get("fi.w1.wpa_supplicant1.Interface.Ifname", self.Object)
+	if err != nil {
+		self.Error = err
+		return self
+	}
+	self.Ifname = value.(string)
+
 	return self
 }
 
 func (self *InterfaceWPA) ReadScanInterval() *InterfaceWPA {
-	if self.Error == nil {
-		if value, err := self.WPA.get("fi.w1.wpa_supplicant1.Interface.ScanInterval", self.Object); err == nil {
-			self.ScanInterval = value.(int32)
-		} else {
-			self.Error = err
-		}
+	if self.Error != nil {
+		return self
 	}
+
+	value, err := self.WPA.get("fi.w1.wpa_supplicant1.Interface.ScanInterval", self.Object)
+	if err != nil {
+		self.Error = err
+		return self
+	}
+	self.ScanInterval = value.(int32)
+
 	return self
 }
 
 func (self *InterfaceWPA) ReadDisconnectReason() *InterfaceWPA {
-	if self.Error == nil {
-		if value, err := self.WPA.get("fi.w1.wpa_supplicant1.Interface.DisconnectReason", self.Object); err == nil {
-			self.DisconnectReason = value.(int32)
-		} else {
-			self.Error = err
-		}
+	if self.Error != nil {
+		return self
 	}
+
+	value, err := self.WPA.get("fi.w1.wpa_supplicant1.Interface.DisconnectReason", self.Object)
+	if err != nil {
+		self.Error = err
+		return self
+	}
+	self.DisconnectReason = value.(int32)
+
 	return self
 }
 
 func (self *InterfaceWPA) AddSignalsObserver() *InterfaceWPA {
 	log.Log.Debug("AddSignalsObserver.Interface")
+
 	match := fmt.Sprintf("type='signal',interface='fi.w1.wpa_supplicant1.Interface',path='%s'", self.Object.Path())
-	if call := self.WPA.Connection.BusObject().Call("org.freedesktop.DBus.AddMatch", 0, match); call.Err == nil {
-	} else {
-		self.Error = call.Err
-	}
+	call := self.WPA.Connection.BusObject().Call("org.freedesktop.DBus.AddMatch", 0, match)
+	self.Error = call.Err
+
 	return self
 }
 
 func (self *InterfaceWPA) RemoveSignalsObserver() *InterfaceWPA {
 	log.Log.Debug("RemoveSignalsObserver.Interface")
+
 	match := fmt.Sprintf("type='signal',interface='fi.w1.wpa_supplicant1.Interface',path='%s'", self.Object.Path())
-	if call := self.WPA.Connection.BusObject().Call("org.freedesktop.DBus.RemoveMatch", 0, match); call.Err == nil {
-	} else {
-		self.Error = call.Err
-	}
+	call := self.WPA.Connection.BusObject().Call("org.freedesktop.DBus.RemoveMatch", 0, match)
+	self.Error = call.Err
+
 	return self
 }
 
 func (self *InterfaceWPA) ReadCurrentBSS() *InterfaceWPA {
-	if self.Error == nil {
-		if value, err := self.WPA.get("fi.w1.wpa_supplicant1.Interface.CurrentBSS", self.Object); err == nil {
-			bssObjectPath := value.(dbus.ObjectPath)
-			self.CurrentBSS = &BSSWPA{Interface: self, Object: self.WPA.Connection.Object("fi.w1.wpa_supplicant1", bssObjectPath)}
-		} else {
-			self.Error = err
-		}
+	if self.Error != nil {
+		return self
 	}
+
+	value, err := self.WPA.get("fi.w1.wpa_supplicant1.Interface.CurrentBSS", self.Object)
+	if err != nil {
+		self.Error = err
+		return self
+	}
+	bssObjectPath := value.(dbus.ObjectPath)
+	self.CurrentBSS = &BSSWPA{
+		Interface: self,
+		Object:    self.WPA.Connection.Object("fi.w1.wpa_supplicant1", bssObjectPath),
+	}
+
 	return self
 }
 
 func (self *InterfaceWPA) ReadCurrentNetwork() *InterfaceWPA {
-	if self.Error == nil {
-		if network, err := self.WPA.get("fi.w1.wpa_supplicant1.Interface.CurrentNetwork", self.Object); err == nil {
-			networkObjectPath := network.(dbus.ObjectPath)
-			self.CurrentNetwork = &NetworkWPA{Interface: self, Object: self.WPA.Connection.Object("fi.w1.wpa_supplicant1", networkObjectPath)}
-		} else {
-			self.Error = err
-		}
+	if self.Error != nil {
+		return self
 	}
+
+	network, err := self.WPA.get("fi.w1.wpa_supplicant1.Interface.CurrentNetwork", self.Object)
+	if err != nil {
+		self.Error = err
+		return self
+	}
+	networkObjectPath := network.(dbus.ObjectPath)
+	self.CurrentNetwork = &NetworkWPA{Interface: self, Object: self.WPA.Connection.Object("fi.w1.wpa_supplicant1", networkObjectPath)}
+
 	return self
 }

--- a/internal/wpa_dbus/wpa_network.go
+++ b/internal/wpa_dbus/wpa_network.go
@@ -18,50 +18,54 @@ type NetworkWPA struct {
 
 func (self *NetworkWPA) ReadProperties() *NetworkWPA {
 	log.Log.Debug("ReadProperties")
-	if self.Error == nil {
-		if properties, err := self.Interface.WPA.get("fi.w1.wpa_supplicant1.Network.Properties", self.Object); err == nil {
-			for key, value := range properties.(map[string]dbus.Variant) {
-				switch key {
-				case "ssid":
-					self.SSID = value.Value().(string)
-				case "key_mgmt":
-					self.KeyMgmt = value.Value().(string)
-				}
-			}
-		} else {
-			self.Error = err
+	if self.Error != nil {
+		return self
+	}
+
+	properties, err := self.Interface.WPA.get("fi.w1.wpa_supplicant1.Network.Properties", self.Object)
+	if err != nil {
+		self.Error = err
+		return self
+	}
+
+	for key, value := range properties.(map[string]dbus.Variant) {
+		switch key {
+		case "ssid":
+			self.SSID = value.Value().(string)
+		case "key_mgmt":
+			self.KeyMgmt = value.Value().(string)
 		}
 	}
+
 	return self
 }
 
 func (self *NetworkWPA) Select() *NetworkWPA {
 	log.Log.Debug("Select")
-	if self.Error == nil {
-		if call := self.Interface.Object.Call("fi.w1.wpa_supplicant1.Interface.SelectNetwork", 0, self.Object.Path()); call.Err == nil {
-		} else {
-			self.Error = call.Err
-		}
+	if self.Error != nil {
+		return self
 	}
+
+	call := self.Interface.Object.Call("fi.w1.wpa_supplicant1.Interface.SelectNetwork", 0, self.Object.Path())
+	self.Error = call.Err
+
 	return self
 }
 
 func (self *NetworkWPA) AddSignalsObserver() *NetworkWPA {
 	log.Log.Debug("AddSignalsObserver.Network")
 	match := fmt.Sprintf("type='signal',interface='fi.w1.wpa_supplicant1.Network',path='%s'", self.Object.Path())
-	if call := self.Interface.WPA.Connection.BusObject().Call("org.freedesktop.DBus.AddMatch", 0, match); call.Err == nil {
-	} else {
-		self.Error = call.Err
-	}
+	call := self.Interface.WPA.Connection.BusObject().Call("org.freedesktop.DBus.AddMatch", 0, match)
+	self.Error = call.Err
+
 	return self
 }
 
 func (self *NetworkWPA) RemoveSignalsObserver() *NetworkWPA {
 	log.Log.Debug("RemoveSignalsObserver.Network")
 	match := fmt.Sprintf("type='signal',interface='fi.w1.wpa_supplicant1.Network',path='%s'", self.Object.Path())
-	if call := self.Interface.WPA.Connection.BusObject().Call("org.freedesktop.DBus.RemoveMatch", 0, match); call.Err == nil {
-	} else {
-		self.Error = call.Err
-	}
+	call := self.Interface.WPA.Connection.BusObject().Call("org.freedesktop.DBus.RemoveMatch", 0, match)
+	self.Error = call.Err
+
 	return self
 }

--- a/wpa-connect.go
+++ b/wpa-connect.go
@@ -2,129 +2,181 @@ package wpaconnect
 
 import (
 	"errors"
+	"fmt"
+	"net"
+	"time"
+
 	"github.com/mark2b/wpa-connect/internal/wpa_cli"
 
-	"fmt"
 	"github.com/godbus/dbus"
 	"github.com/mark2b/wpa-connect/internal/log"
 	"github.com/mark2b/wpa-connect/internal/wpa_dbus"
-	"net"
-	"time"
 )
 
-func (self *connectManager) Connect(ssid string, password string, timeout time.Duration) (connectionInfo ConnectionInfo, e error) {
+type ConnectionInfo struct {
+	NetInterface string
+	SSID         string
+	IP4          net.IP
+	IP6          net.IP
+}
+
+type connectContext struct {
+	phaseWaitForScanDone           bool
+	phaseWaitForInterfaceConnected bool
+	scanDone                       chan bool
+	connectDone                    chan bool
+	ip4                            net.IP
+	ip6                            net.IP
+	err                            error
+}
+
+type connectManager struct {
+	context      *connectContext
+	deadTime     time.Time
+	NetInterface string
+}
+
+var ConnectManager = &connectManager{NetInterface: "wlan0"}
+
+func NewConnectManager(netInterface string) *connectManager {
+	return &connectManager{NetInterface: netInterface}
+}
+
+func (self *connectManager) Connect(ssid string, password string, timeout time.Duration) (ConnectionInfo, error) {
 	self.deadTime = time.Now().Add(timeout)
 	self.context = &connectContext{}
 	self.context.scanDone = make(chan bool)
 	self.context.connectDone = make(chan bool)
-	if wpa, err := wpa_dbus.NewWPA(); err == nil {
-		wpa.WaitForSignals(self.onSignal)
-		wpa.AddSignalsObserver()
-		if wpa.ReadInterface(self.NetInterface); wpa.Error == nil {
-			iface := wpa.Interface
-			iface.AddSignalsObserver()
-			self.context.phaseWaitForScanDone = true
-			go func() {
-				time.Sleep(self.deadTime.Sub(time.Now()))
-				self.context.scanDone <- false
-				self.context.error = errors.New("timeout")
-			}()
-			if iface.Scan(); iface.Error == nil {
-				// Wait for scan done
-				if <-self.context.scanDone; self.context.error == nil {
-					if iface.ReadBSSList(); iface.Error == nil {
-						bssMap := make(map[string]wpa_dbus.BSSWPA, 0)
-						for _, bss := range iface.BSSs {
-							if bss.ReadSSID(); bss.Error == nil {
-								bssMap[bss.SSID] = bss
-								log.Log.Debug(bss.SSID, bss.BSSID)
-							} else {
-								e = err
-								break
-							}
-						}
-						if e == nil {
-							_, exists := bssMap[ssid]
-							if err := self.connectToBSS(&wpa_dbus.BSSWPA{
-								SSID: ssid,
-							}, iface, password, !exists); err == nil {
-								// Connected, save configuration
-								cli := wpa_cli.WPACli{NetInterface: self.NetInterface}
-								if err := cli.SaveConfig(); err == nil {
-									connectionInfo = ConnectionInfo{NetInterface: self.NetInterface, SSID: ssid,
-										IP4: self.context.ip4, IP6: self.context.ip6}
-								} else {
-									e = err
-								}
-							} else {
-								e = err
-							}
-						}
-					} else {
-						e = iface.Error
-					}
-				} else {
-					e = self.context.error
-				}
-			} else {
-				e = wpa.Error
-			}
-			iface.RemoveSignalsObserver()
-		} else {
-			e = wpa.Error
-		}
-		wpa.RemoveSignalsObserver()
-		wpa.StopWaitForSignals()
-	} else {
-		e = err
+
+	wpa, err := wpa_dbus.NewWPA()
+	if err != nil {
+		return ConnectionInfo{}, err
 	}
-	return
+
+	wpa.WaitForSignals(self.onSignal)
+	defer wpa.StopWaitForSignals()
+
+	wpa.AddSignalsObserver()
+	defer wpa.RemoveSignalsObserver()
+
+	wpa.ReadInterface(self.NetInterface)
+	if wpa.Error != nil {
+		return ConnectionInfo{}, wpa.Error
+	}
+
+	iface := wpa.Interface
+	iface.AddSignalsObserver()
+	defer iface.RemoveSignalsObserver()
+
+	self.context.phaseWaitForScanDone = true
+	go func() {
+		time.Sleep(time.Until(self.deadTime))
+		self.context.scanDone <- false
+		self.context.err = errors.New("timeout")
+	}()
+
+	iface.Scan()
+	if iface.Error != nil {
+		return ConnectionInfo{}, iface.Error
+	}
+
+	// Wait for scan done
+	<-self.context.scanDone
+	if self.context.err != nil {
+		return ConnectionInfo{}, self.context.err
+	}
+
+	iface.ReadBSSList()
+	if iface.Error != nil {
+		return ConnectionInfo{}, iface.Error
+	}
+
+	bssMap := make(map[string]wpa_dbus.BSSWPA, 0)
+	for _, bss := range iface.BSSs {
+		bss.ReadSSID()
+		if bss.Error != nil {
+			return ConnectionInfo{}, bss.Error
+		}
+
+		bssMap[bss.SSID] = bss
+		log.Log.Debug(bss.SSID, bss.BSSID)
+	}
+
+	_, exists := bssMap[ssid]
+	err = self.connectToBSS(&wpa_dbus.BSSWPA{
+		SSID: ssid,
+	}, iface, password, !exists)
+	if err != nil {
+		return ConnectionInfo{}, err
+	}
+
+	// Connected, save configuration
+	cli := wpa_cli.WPACli{NetInterface: self.NetInterface}
+	err = cli.SaveConfig()
+	if err != nil {
+		return ConnectionInfo{}, err
+	}
+
+	return ConnectionInfo{
+		NetInterface: self.NetInterface,
+		SSID:         ssid,
+		IP4:          self.context.ip4,
+		IP6:          self.context.ip6,
+	}, nil
 }
 
-func (self *connectManager) connectToBSS(bss *wpa_dbus.BSSWPA, iface *wpa_dbus.InterfaceWPA, password string, isHidden bool) (e error) {
+func (self *connectManager) connectToBSS(bss *wpa_dbus.BSSWPA, iface *wpa_dbus.InterfaceWPA, password string, isHidden bool) error {
 	addNetworkArgs := map[string]dbus.Variant{
 		"ssid": dbus.MakeVariant(bss.SSID),
 	}
+
 	if isHidden {
 		addNetworkArgs["scan_ssid"] = dbus.MakeVariant(1)
 	}
+
 	if password == "" {
 		addNetworkArgs["key_mgmt"] = dbus.MakeVariant("NONE")
 	} else {
 		addNetworkArgs["psk"] = dbus.MakeVariant(password)
 	}
-	if iface.RemoveAllNetworks().AddNetwork(addNetworkArgs); iface.Error == nil {
-		network := iface.NewNetwork
-		self.context.phaseWaitForInterfaceConnected = true
-		go func() {
-			time.Sleep(self.deadTime.Sub(time.Now()))
-			self.context.connectDone <- false
-			self.context.error = errors.New("timeout")
-		}()
-		if network.Select(); network.Error == nil {
-			if connected := <-self.context.connectDone; self.context.error == nil {
-				if connected {
-					if err := self.readNetAddress(); err == nil {
-					} else {
-						e = err
-					}
-				} else {
-					if iface.ReadDisconnectReason(); iface.Error == nil {
-						e = errors.New(fmt.Sprintf("connection_failed, reason=%d", iface.DisconnectReason))
-					} else {
-						e = errors.New("connection_failed")
-					}
-				}
-			} else {
-				e = self.context.error
-			}
-		} else {
-			e = network.Error
+
+	iface.RemoveAllNetworks().AddNetwork(addNetworkArgs)
+	if iface.Error != nil {
+		return iface.Error
+	}
+
+	network := iface.NewNetwork
+	self.context.phaseWaitForInterfaceConnected = true
+	go func() {
+		time.Sleep(time.Until(self.deadTime))
+		self.context.connectDone <- false
+		self.context.err = errors.New("timeout")
+	}()
+
+	network.Select()
+	if network.Error != nil {
+		return network.Error
+	}
+
+	connected := <-self.context.connectDone
+	if self.context.err != nil {
+		return self.context.err
+	}
+
+	if connected {
+		err := self.readNetAddress()
+		if err != nil {
+			return err
 		}
 	} else {
-		e = iface.Error
+		iface.ReadDisconnectReason()
+		if iface.Error != nil {
+			return fmt.Errorf("connection failed, reason=%d", iface.DisconnectReason)
+		}
+		return errors.New("connection failed")
 	}
-	return
+
+	return nil
 }
 
 func (self *connectManager) onSignal(wpa *wpa_dbus.WPA, signal *dbus.Signal) {
@@ -143,37 +195,33 @@ func (self *connectManager) onSignal(wpa *wpa_dbus.WPA, signal *dbus.Signal) {
 	}
 }
 
-func (self *connectManager) readNetAddress() (e error) {
-	if netIface, err := net.InterfaceByName(self.NetInterface); err == nil {
-		for time.Now().Before(self.deadTime) && !self.context.hasIP() {
-			if addrs, err := netIface.Addrs(); err == nil {
-				for _, addr := range addrs {
-					if ip, _, err := net.ParseCIDR(addr.String()); err == nil {
-						if self.context.ip4 == nil {
-							self.context.ip4 = ip.To4()
-							continue
-						}
-						if self.context.ip6 == nil {
-							self.context.ip6 = ip.To16()
-							continue
-						}
-					} else {
-						e = err
-						return
-					}
-				}
-			} else {
-				e = err
-			}
-			time.Sleep(time.Millisecond * 500)
-		}
-		if !self.context.hasIP() {
-			e = errors.New("address_not_allocated")
-		}
-	} else {
-		e = err
+func (self *connectManager) readNetAddress() error {
+	netIface, err := net.InterfaceByName(self.NetInterface)
+	if err != nil {
+		return err
 	}
-	return
+
+	for time.Now().Before(self.deadTime) && !self.context.hasIP() {
+		addrs, _ := netIface.Addrs()
+		for _, addr := range addrs {
+			if ipnet, ok := addr.(*net.IPNet); ok {
+				if self.context.ip4 == nil {
+					self.context.ip4 = ipnet.IP.To4()
+					continue
+				}
+				if self.context.ip6 == nil {
+					self.context.ip6 = ipnet.IP.To16()
+				}
+			}
+		}
+
+		time.Sleep(time.Millisecond * 500)
+	}
+	if !self.context.hasIP() {
+		return errors.New("address not allocated")
+	}
+
+	return nil
 }
 
 func (self *connectManager) processScanDone(wpa *wpa_dbus.WPA, signal *dbus.Signal) {
@@ -187,22 +235,25 @@ func (self *connectManager) processScanDone(wpa *wpa_dbus.WPA, signal *dbus.Sign
 func (self *connectManager) processInterfacePropertiesChanged(wpa *wpa_dbus.WPA, signal *dbus.Signal) {
 	log.Log.Debug("processInterfacePropertiesChanged")
 	log.Log.Debug("phaseWaitForInterfaceConnected", self.context.phaseWaitForInterfaceConnected)
-	if self.context.phaseWaitForInterfaceConnected {
-		if len(signal.Body) > 0 {
-			properties := signal.Body[0].(map[string]dbus.Variant)
-			if stateVariant, hasState := properties["State"]; hasState {
-				if state, ok := stateVariant.Value().(string); ok {
-					log.Log.Debug("State", state)
-					if state == "completed" {
-						self.context.phaseWaitForInterfaceConnected = false
-						self.context.connectDone <- true
-						return
-					} else if state == "disconnected" {
-						//self.context.phaseWaitForInterfaceConnected = false
-						//self.context.connectDone <- false
-						return
-					}
-				}
+	if !self.context.phaseWaitForInterfaceConnected {
+		return
+	}
+
+	if len(signal.Body) == 0 {
+		return
+	}
+
+	properties := signal.Body[0].(map[string]dbus.Variant)
+	if stateVariant, hasState := properties["State"]; hasState {
+		if state, ok := stateVariant.Value().(string); ok {
+			log.Log.Debug("State", state)
+			switch state {
+			case "completed":
+				self.context.phaseWaitForInterfaceConnected = false
+				self.context.connectDone <- true
+			case "disconnected":
+				// self.context.phaseWaitForInterfaceConnected = false
+				// self.context.connectDone <- false
 			}
 		}
 	}
@@ -211,34 +262,3 @@ func (self *connectManager) processInterfacePropertiesChanged(wpa *wpa_dbus.WPA,
 func (self *connectContext) hasIP() bool {
 	return self.ip4 != nil && self.ip6 != nil
 }
-
-func NewConnectManager(netInterface string) *connectManager {
-	return &connectManager{NetInterface: netInterface}
-}
-
-type ConnectionInfo struct {
-	NetInterface string
-	SSID         string
-	IP4          net.IP
-	IP6          net.IP
-}
-
-type connectContext struct {
-	phaseWaitForScanDone           bool
-	phaseWaitForInterfaceConnected bool
-	scanDone                       chan bool
-	connectDone                    chan bool
-	ip4                            net.IP
-	ip6                            net.IP
-	error                          error
-}
-
-type connectManager struct {
-	context      *connectContext
-	deadTime     time.Time
-	NetInterface string
-}
-
-var (
-	ConnectManager = &connectManager{NetInterface: "wlan0"}
-)

--- a/wpa-scan.go
+++ b/wpa-scan.go
@@ -6,39 +6,83 @@ import (
 	"github.com/mark2b/wpa-connect/internal/wpa_dbus"
 )
 
-func (self *scanManager) Scan() (bssList []BSS, e error) {
+type BSS struct {
+	BSSID     string
+	SSID      string
+	KeyMgmt   []string
+	WPS       string
+	Frequency uint16
+	Signal    int16
+	Age       uint32
+	Mode      string
+	Privacy   bool
+}
+
+type scanContext struct {
+	phaseWaitForScanDone bool
+	scanDone             chan bool
+}
+
+type scanManager struct {
+	scanContext  *scanContext
+	NetInterface string
+}
+
+var ScanManager = &scanManager{NetInterface: "wlan0"}
+
+func NewScanManager(netInterface string) *scanManager {
+	return &scanManager{NetInterface: netInterface}
+}
+
+func (self *scanManager) Scan() ([]BSS, error) {
 	self.scanContext = &scanContext{}
 	self.scanContext.scanDone = make(chan bool)
-	if wpa, err := wpa_dbus.NewWPA(); err == nil {
-		wpa.WaitForSignals(self.onScanSignal)
-		if wpa.ReadInterface(self.NetInterface); wpa.Error == nil {
-			iface := wpa.Interface
-			iface.AddSignalsObserver()
-			self.scanContext.phaseWaitForScanDone = true
-			if iface.Scan(); iface.Error == nil {
-				// Wait for scan_example done
-				<-self.scanContext.scanDone
-				if iface.ReadBSSList(); iface.Error == nil {
-					for _, bss := range iface.BSSs {
-						if bss.ReadBSSID().ReadSSID().ReadRSN().ReadMode().ReadSignal().
-							ReadFrequency().ReadPrivacy().ReadAge().ReadWPS().ReadWPA(); bss.Error == nil {
-							bssList = append(bssList, BSS{BSSID: bss.BSSID, SSID: bss.SSID, KeyMgmt: bss.RSNKeyMgmt, WPS: bss.WPS,
-								Frequency: bss.Frequency, Privacy: bss.Privacy, Age: bss.Age, Mode: bss.Mode, Signal: bss.Signal})
-						}
-					}
-				}
-			} else {
-				e = iface.Error
-			}
-			iface.RemoveSignalsObserver()
-		} else {
-			e = wpa.Error
-		}
-		wpa.StopWaitForSignals()
-	} else {
-		e = err
+
+	wpa, err := wpa_dbus.NewWPA()
+	if err != nil {
+		return nil, err
 	}
-	return
+
+	wpa.WaitForSignals(self.onScanSignal)
+	defer wpa.StopWaitForSignals()
+
+	wpa.ReadInterface(self.NetInterface)
+	if wpa.Error != nil {
+		return nil, wpa.Error
+	}
+
+	iface := wpa.Interface
+	iface.AddSignalsObserver()
+	defer iface.RemoveSignalsObserver()
+	self.scanContext.phaseWaitForScanDone = true
+
+	iface.Scan()
+	if iface.Error != nil {
+		return nil, iface.Error
+	}
+
+	// Wait for scan_example done
+	<-self.scanContext.scanDone
+	bssList := []BSS{}
+	iface.ReadBSSList()
+	if iface.Error != nil {
+		return nil, iface.Error
+	}
+
+	for _, bss := range iface.BSSs {
+		bss.ReadBSSID().ReadSSID().ReadRSN().ReadMode().ReadSignal().
+			ReadFrequency().ReadPrivacy().ReadAge().ReadWPS().ReadWPA()
+		if bss.Error != nil {
+			continue
+		}
+
+		bssList = append(bssList, BSS{
+			BSSID: bss.BSSID, SSID: bss.SSID, KeyMgmt: bss.RSNKeyMgmt, WPS: bss.WPS,
+			Frequency: bss.Frequency, Privacy: bss.Privacy, Age: bss.Age, Mode: bss.Mode, Signal: bss.Signal,
+		})
+	}
+
+	return bssList, nil
 }
 
 func (self *scanManager) onScanSignal(wpa *wpa_dbus.WPA, signal *dbus.Signal) {
@@ -62,33 +106,3 @@ func (self *scanManager) processScanDone(wpa *wpa_dbus.WPA, signal *dbus.Signal)
 		self.scanContext.scanDone <- true
 	}
 }
-
-func NewScanManager(netInterface string) *scanManager {
-	return &scanManager{NetInterface: netInterface}
-}
-
-type BSS struct {
-	BSSID     string
-	SSID      string
-	KeyMgmt   []string
-	WPS       string
-	Frequency uint16
-	Signal    int16
-	Age       uint32
-	Mode      string
-	Privacy   bool
-}
-
-type scanContext struct {
-	phaseWaitForScanDone bool
-	scanDone             chan bool
-}
-
-type scanManager struct {
-	scanContext  *scanContext
-	NetInterface string
-}
-
-var (
-	ScanManager = &scanManager{NetInterface: "wlan0"}
-)


### PR DESCRIPTION
First things first: this PR does not introduce any change in functionality. I just found the code hard to read because of the many nested `if`'s and other non-idiomatic code choices, so I simplified the following snippets of code (these are examples). I also cleaned up `go.mod` with `go mod tidy` because it contained some unneeded dependencies and the code has been linted and formatted with `gofumpt` and `golangci-lint`.

Some notes before the code:
- I use Go 1.18 but I deliberately avoided using newer features of the language because I wanted this to be a "simple" code refactoring/optimization job
- The example programs in `examples/` were also formatted, linted and modified per the rules listed below
- The examples still work the same
  - The debug log is shorter because of the optimizations I got by making the code simpler (especially by avoiding iteration over maps)
- The dependencies were **not** updated with `go get -u` or anything
- `connectContext.error` was renamed to `connectContext.err` (in `wpa-connect.go`) because the linter didn't like it

### Top-level `if` check for `self.Error`

The function can just return early if `self.Error` is not nil, instead of having a big code block inside a huge `if`.

```go
func (self *BSSWPA) ReadWPS() *BSSWPA {
    if self.Error == nil {
        // do stuff
    }
    return self
}
```

becomes

```go
func (self *BSSWPA) ReadWPS() *BSSWPA {
    if self.Error != nil {
        return self
    }
    
    // do stuff
    
    return self
}
```

### `if call := ...; call.Err = nil` with empty `if` block

Since `self.Error` will be `nil` anyways and we care only about the value of `call.Err`, we don't need to check wether it's `nil` or not and just assign it straight to `self.Error`.

```go
if call := self.Interface.WPA.Connection.BusObject().Call("org.freedesktop.DBus.AddMatch", 0, match); call.Err == nil {
} else {
    self.Error = call.Err
}
return self
```

becomes

```go
call := self.Interface.WPA.Connection.BusObject().Call("org.freedesktop.DBus.AddMatch", 0, match)
self.Error = call.Err

return self
```

### Function named return simplification
In several cases, using unnamed return values can improve readability of a function, because it requires all the returned values be explicitly on a single line, `nil`s included.
(This is more of a personal opinion, though).

```go
func (self *WPA) get(name string, target dbus.BusObject) (value interface{}, e error) {
    if variant, err := target.GetProperty(name); err == nil {
        value = variant.Value()
    } else {
        e = err
    }
    return
}
```

can be simplified into

```go
func (self *WPA) get(name string, target dbus.BusObject) (interface{}, error) {
    variant, err := target.GetProperty(name)
    if err != nil {
        return nil, err
    }

    return variant.Value(), nil
}
```

### Removed iteration over `map` retrieved from DBus
Self explanatory. Since the code iterates over all the keys of a map with a nested `if`, and maps can only have a single value bound to a specific key, the code can be simplified to a straight map-value-ok check. (Variables have also been renamed to proper names instead of `value` and `key`)

```go
for key, variant := range value {
    if key == "Type" {
        self.WPS = variant.Value().(string)
    }
}
```

becomes

```go
if wpsType, found := value["Type"]; found {
    self.WPS = wpsType.String()
}
```

### Use `defer` for closing connections and signal waiting
Using `defer` is very good practice when handling connection cleanup and similar boilerplate: a deferred function will always run, even on early return. This prevents memory leaks and also makes the code somewhat cleaner.

```go
wpa.WaitForSignals(self.onScanSignal)
// ...
iface.AddSignalsObserver()

// do stuff

iface.RemoveSignalsObserver()
wpa.StopWaitForSignals()
return
```

becomes

```go
wpa.WaitForSignals(self.onScanSignal)
defer wpa.StopWaitForSignals()
// ...
iface.AddSignalsObserver()
defer iface.RemoveSignalsObserver()

// do stuff

return
```

### Types and `New*` function moved to beginning of the file
Self explanatory. Makes type definition easier to find just by opening the file.
